### PR TITLE
Fix error with token-based auth

### DIFF
--- a/bin/oref0-get-ns-entries.js
+++ b/bin/oref0-get-ns-entries.js
@@ -64,7 +64,7 @@ if (!module.parent) {
     process.exit(1);
   }
 
-  if (apisecret.length != 40) {
+  if (apisecret != null && !apisecret.startsWith("token=") && apisecret.length != 40) {
     var shasum = crypto.createHash('sha1');
     shasum.update(apisecret);
     apisecret = shasum.digest('hex');
@@ -155,15 +155,20 @@ if (!module.parent) {
 
   function loadFromNightscoutWithDate(lastDate, glucosedata) {
 
-    var headers = {
-      'api-secret': apisecret
-    };
+    // append the token secret to the end of the ns url, or add it to the headers if token based authentication is not used
+    var headers = {} ;
+    var tokenAuth = "";
+    if (apisecret.startsWith("token=")) {
+      tokenAuth = "&" + apisecret;
+    } else { 
+      headers = { 'api-secret': apisecret };
+    }
 
     if (!_.isNil(lastDate)) {
       headers["If-Modified-Since"] = lastDate.toISOString();
     }
 
-    var uri = nsurl + '/api/v1/entries/sgv.json?count=' + records;
+    var uri = nsurl + '/api/v1/entries/sgv.json?count=' + records + tokenAuth;
     var options = {
       uri: uri
       , json: true


### PR DESCRIPTION
Token based authentication is broken in oref0 0.7.0. Rig is requested data without appending the token= to the requested URL, causing a permissions error.


https://github.com/openaps/oref0/pull/1317/commits/89a90b8e86525b3510710c22a70f698d184d1462